### PR TITLE
Try to reduce memory footprint

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: ./gradlew tomcatRun
+web: ./start

--- a/start
+++ b/start
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+JAVA_OPTS="$JAVA_OPTS -Xmx248m"
+JAVA_OPTS="$JAVA_OPTS -XX:-UseGCOverheadLimit"
+JAVA_OPTS="$JAVA_OPTS -XX:+CMSClassUnloadingEnabled"
+JAVA_OPTS="$JAVA_OPTS -XX:+UseCompressedOops"
+JAVA_OPTS="$JAVA_OPTS -XX:+UseCompressedClassPointers"
+
+exec ./gradlew --no-daemon tomcatRun


### PR DESCRIPTION
Java instances on heroku frequently run out of memory quota.

This leads to excessive paging which can be a performance hit.

While applying these changes it still happened but maybe less.

Don't merge right away.  Measurements are needed.